### PR TITLE
bug (#30): fixes double rendering

### DIFF
--- a/src/components/AddNotification/AddNotification.js
+++ b/src/components/AddNotification/AddNotification.js
@@ -46,7 +46,9 @@ const AddNotification = (props) => {
       </div>
 
       <div className={styles.actionContainer}>
-        <Button onClick={props.openCart} level={'secondary'}>view my bag (1)</Button>
+        <Button onClick={props.openCart} level={'secondary'}>
+          view my bag (1)
+        </Button>
         <Button level="primary" href="/cart">
           checkout
         </Button>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -156,7 +156,7 @@ const Header = (prop) => {
               </div>
             </button>
             <div className={styles.notificationContainer}>
-                <AddNotification openCart={() => setShowMiniCart(true)} />
+              <AddNotification openCart={() => setShowMiniCart(true)} />
             </div>
           </div>
         </div>


### PR DESCRIPTION
closes #30 

I ran through a few steps to get here
- removed the header component as well as a few others from the Layout to make sure it was the header 
- removed bits of code from header.js until the double trouble bug vanished and was left with AddNotification component
- did the same for AddNotification component and turned out it was the buttons

I'm guessing it has to do with the styling changes to src/components/Header/Header.module.css in #8 and will dig in more tomorrow. But this deploy preview should show the double trouble is gone.